### PR TITLE
Import data faster

### DIFF
--- a/fast_load/import_sas.ipynb
+++ b/fast_load/import_sas.ipynb
@@ -5,7 +5,18 @@
    "execution_count": null,
    "id": "2c6842b5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "()"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import os\n",
     "import pandas as pd\n",
@@ -27,13 +38,27 @@
     "    \n",
     "    return()\n",
     "\n",
-    "#load_sas_file(\"computedelements.sas7bdat\", 'computed_elements') <-- sample function call to get the parquet/chunk files. SAS data will be stored in chunks in 'computed_elements' in this example. THEN, go to fast_load_parquet.R and run the last line to get sampled DF"
+    "#load_sas_file(\"computedelements.sas7bdat\", 'computed_elements') <- sample function use"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
   }
  },
  "nbformat": 4,

--- a/fast_load/sas_to_sample_df.R
+++ b/fast_load/sas_to_sample_df.R
@@ -1,8 +1,9 @@
 library(arrow)
 library(dplyr)
 library(glue)
+library(rlang)
 
-load_and_sample_Sas <- function(output_dir_name, col_to_sample = PcrKey, sample_size = 1000){
+load_and_sample_Sas <- function(output_dir_name, col_to_sample = "PcrKey", sample_size = 1000){
   # PARAMETERS:
   # output_dir_name = name of directory where parquet files are being stored
   # col_to_sample = which column to sample from
@@ -11,20 +12,20 @@ load_and_sample_Sas <- function(output_dir_name, col_to_sample = PcrKey, sample_
   ds <- open_dataset(glue("fast_load/{output_dir_name}"), format = "parquet")
   
   all_ids <- ds %>%
-    select(col_to_sample) %>%
+    select(all_of(col_to_sample)) %>%
     collect()
   
   sample_size <- 1000
-  sampled_keys <- sample(all_ids$col_to_sample, size = sample_size)
+  sampled_keys <- sample(all_ids[[col_to_sample]], size = sample_size)
   
   random_sample <- ds %>%
-    filter(col_to_sample %in% sampled_keys) %>%
+    collect() %>%
+    filter(!!sym(col_to_sample) %in% sampled_keys) %>%
     collect()
   
-  unlink("fast_load/{output_dir_name}", recursive = TRUE)
   
   return(random_sample)
 }
 
 
-sampled_df <- load_and_sample_Sas("computed_elements")
+#sampled_df <- load_and_sample_Sas("computed_elements") <- sample function use


### PR DESCRIPTION
Created a folder called "fast_load" that contains two files: one Jupyter file ("import_sas.ipynb") that loads in .sas7bdat files in as parquet chunks and one R file ("sas_to_sample.R") with a function that samples from the parquet chunks and turns it into a dataframe. 
Visual studio code or Jupyter notebook/lab recommended for running the ipynb. Next step would be figuring out how to run it in R without needing to open the Jupyter file. 
Run time for my machine:
Processor	13th Gen Intel(R) Core(TM) i7-13620H (2.40 GHz)
Installed RAM	40.0 GB (39.7 GB usable)
System type	64-bit operating system, x64-based processor

I ran "computedelements.sas7bdat," 4gb - took ~1-2min to convert to parquet chunks in "import_sas.ipynb"
