### PR TITLE
Issue #12 megan

### DIFF
--- a/cols_causing_duplication.R
+++ b/cols_causing_duplication.R
@@ -4,7 +4,9 @@ library(ggplot2)
 library(mgsub)
 library(philentropy)
 
-preprocess_merge <- function(){
+  
+## COMBINE WITH "_"
+paste_by_underscore <- function() {
   # Retrieve duplicate PcrKeys from clean_NA
   dupe_pcrkeys <- clean_NA$PcrKey[duplicated(clean_NA$PcrKey)]
   duplicates <- clean_NA %>%
@@ -33,47 +35,26 @@ preprocess_merge <- function(){
     mutate(diff_cols = find_diffs(pick(everything()))) %>% #creates "diff_col" column, grabs all data for that specific PcrKey and applies the "find_diffs" function
     ungroup()
   
-  return(dupe_cols_df)
-}
-  
-## COMBINE WITH "_"
-paste_by_underscore <- function(dupe_cols_df) {
   frequency_tbl <- dupe_cols_df %>%
     distinct(PcrKey, .keep_all= TRUE) %>%
-    filter(diff_cols != "") %>% #remove rows with no value in the "diffs_col" column (not a duplicate)
-    separate_rows(diff_cols, sep = ";\\s*") %>% #break values with ";" into two rows
-    count(diff_cols, sort = TRUE) #counts the number of each unique value in "diff_cols"
+    filter(diff_cols != "") %>%
+    separate_rows(diff_cols, sep = ";\\s*") %>% 
+    count(diff_cols, sort = TRUE) 
   
   ## Retrieve only the columns causing duplicate PcrKeys
   
-  dupe_cols <- c("PcrKey", frequency_tbl$diff_cols) #just get the names of the duplicate columns
-  dupe_cols_only <- duplicates[, (colnames(duplicates) %in% dupe_cols)] #subset the duplicates table with the names from "dupe_cols"
+  dupe_cols <- c("PcrKey", frequency_tbl$diff_cols) 
+  dupe_cols_only <- duplicates[, (colnames(duplicates) %in% dupe_cols)] 
   
   dupe_cols_only <- dupe_cols_only %>%
-    left_join(dupe_cols_df %>% #join this to the dupe_cols_only df
-                select(PcrKey, diff_cols)%>% #get just the PcrKey col and "diff_col" row
-                distinct(PcrKey, .keep_all = TRUE), by = "PcrKey") %>% #select only the distinct PcrKey values (remove duplicates and just keep the reasons)
+    left_join(dupe_cols_df %>% 
+                select(PcrKey, diff_cols)%>% 
+                distinct(PcrKey, .keep_all = TRUE), by = "PcrKey") %>% 
     filter(diff_cols != "")
   
   dupe_col_names <- colnames(dupe_cols_only)
-  
-  
-  ## Combine conflicting values into one PcrKey (pasting together with "_" into a string)
-  
-  clean_str <- function(x) {
-    x %>%
-      str_remove_all("Yes|e.g\\.|,|\\(|\\)") %>% 
-      str_replace_all("/|\\-|or| ", "_") %>%
-      str_replace_all("_+", "_") %>%
-      str_trim()
-  }
-  
-  dupe_cols_cln <- dupe_cols_df %>%
-    mutate(across(.cols = all_of(dupe_col_names) & where(is.character),
-                  .fns = ~clean_str(.)))
-  
-  
   dupe_col_names <- dupe_col_names[!dupe_col_names %in% c("PcrKey", "diff_cols")]
+  
   
   ## Combine conflicting values into one PcrKey (pasting together with "_" into a string)
   
@@ -90,7 +71,7 @@ paste_by_underscore <- function(dupe_cols_df) {
                   .fns = ~clean_str(.)))
   
 
-  dupe_col_names <- dupe_col_names[!dupe_col_names %in% c("PcrKey", "diff_cols")]
+ 
   
   dupe_cols_mer <- dupe_cols_cln %>%
     group_by(PcrKey) %>%
@@ -129,12 +110,37 @@ paste_by_underscore <- function(dupe_cols_df) {
     filter(!PcrKey %in% dupe_pcrkeys)
   
   final_clean_NA <- bind_rows(clean_NA_drop, dupe_cols_mer)
+  
+  # final check to make sure merge went properly
+  leaked_dupes <- final_clean_NA %>%
+    count(PcrKey) %>%
+    filter(n > 1)
+  cat("Duplicated values in final_clean_NA (If not 0, fix final merge in function):",
+      nrow(leaked_dupes),
+      "Distinct of clean_NA is equal to the nrow of dropped rows of duplicate PcrKeys + nrow of merged PcrKeys:", 
+      nrow(clean_Na_distinct) == nrow(dupe_cols_mer) + nrow(clean_NA_drop), 
+      sep = "\n")
     
     return(final_clean_NA)
 }
 
 ## REPLACE DUPLICATE VALUES WITH "MULTIPLE"
-paste_by_multiple <- function(dupe_cols_df) {
+paste_by_multiple <- function() {
+  # Retrieve duplicate PcrKeys from clean_NA
+  dupe_pcrkeys <- clean_NA$PcrKey[duplicated(clean_NA$PcrKey)]
+  duplicates <- clean_NA %>%
+    filter(PcrKey %in% dupe_pcrkeys)
+  
+  find_diffs <- function(df) {
+    varying <- names(Filter(function(col) n_distinct(col) > 1, df)) #keep col that has more than 1 unique value (i.e., all values for that col are NOT the same)
+    paste(varying, collapse = "; ") #take the headers and glue them to one string, e.g., "ePatient_14; eResponse_09"
+  }
+  
+  dupe_cols_df <- duplicates %>%
+    group_by(PcrKey) %>% #group all rows by PcrKey
+    mutate(diff_cols = find_diffs(pick(everything()))) %>% #creates "diff_col" column, grabs all data for that specific PcrKey and applies the "find_diffs" function
+    ungroup()
+  
   frequency_tbl <- dupe_cols_df %>%
     distinct(PcrKey, .keep_all= TRUE) %>%
     filter(diff_cols != "") %>%
@@ -153,23 +159,6 @@ paste_by_multiple <- function(dupe_cols_df) {
     filter(diff_cols != "")
   
   dupe_col_names <- colnames(dupe_cols_only)
-  dupe_col_names <- dupe_col_names[!dupe_col_names %in% c("PcrKey", "diff_cols")]
-  
-  ## Combine conflicting values into one PcrKey (pasting together with "_" into a string)
-  
-  clean_str <- function(x) {
-    x %>%
-      str_remove_all("Yes|e.g\\.|,|\\(|\\)") %>% 
-      str_replace_all("/|\\-|or| ", "_") %>%
-      str_replace_all("_+", "_") %>%
-      str_trim()
-  }
-  
-  dupe_cols_cln <- dupe_cols_df %>%
-    mutate(across(.cols = all_of(dupe_col_names) & where(is.character),
-                  .fns = ~clean_str(.)))
-  
-  
   dupe_col_names <- dupe_col_names[!dupe_col_names %in% c("PcrKey", "diff_cols", "datetime_of_destination_prearrival_alert_or_activation")]
   
   collapsed_clean_NA <- dupe_cols_df %>%
@@ -194,7 +183,7 @@ paste_by_multiple <- function(dupe_cols_df) {
       across(
         all_of(dupe_col_names), ~ {unique_vals <- unique(na.omit(.x))
         
-        if(length(unique_vals > 1)){
+        if(length(unique_vals) > 1){
           "Multiple"
         } else if (length(unique_vals) == 1) {
           as.character(unique_vals)
@@ -212,11 +201,7 @@ paste_by_multiple <- function(dupe_cols_df) {
   
   final_clean_NA <- bind_rows(clean_NA_drop, collapsed_clean_NA)
   
-  return(final_clean_NA)
-}
-
-## CHECK FOR LEFT OVER DUPLICATES
-dupe_check <- function(final_df) {
+  #### Check for left over duplicates
   clean_Na_distinct <- clean_NA %>%
     distinct(PcrKey, .keep_all = TRUE)
   
@@ -224,11 +209,11 @@ dupe_check <- function(final_df) {
   leaked_dupes <- final_clean_NA %>%
     count(PcrKey) %>%
     filter(n > 1)
-  cat("Duplicated values in final_clean_NA (If not 0, fix dupe_cols_mer in merge_duplicates()):",
+  cat("Duplicated values in final_clean_NA (If not 0, fix final merge in function):",
       nrow(leaked_dupes),
       "Distinct of clean_NA is equal to the nrow of dropped rows of duplicate PcrKeys + nrow of merged PcrKeys:", 
-      nrow(clean_Na_distinct) == nrow(dupe_cols_mer) + nrow(clean_NA_drop), 
+      nrow(clean_Na_distinct) == nrow(collapsed_clean_NA) + nrow(clean_NA_drop), 
       sep = "\n")
   
+  return(final_clean_NA)
 }
-

--- a/cols_causing_duplication_playground.R
+++ b/cols_causing_duplication_playground.R
@@ -141,6 +141,11 @@ final_clean_NA <- bind_rows(clean_NA_drop, dupe_cols_mer)
 
 
 
+
+
+
+
+
 ### NEW FUNCTION: Duplicate values turn into "Mixed"
 
 
@@ -312,9 +317,9 @@ frequency_tbl_mult <- check_clean_NA %>%
   group_by(column_name) %>%
   summarise(
     total = n(),
-    multiple = sum(status == "Multiple", na.rm = TRUE),
-    prob_multiple = multiple / total,
+    labelled_multiple = sum(status == "Multiple", na.rm = TRUE),
+    proportion_lab_multiple = labelled_multiple / total,
     .groups = "drop"
   ) %>%
-  arrange(desc(prob_multiple))
-sum(frequency_tbl_mult$prob_multiple) #12% data lost
+  arrange(desc(proportion_lab_multiple))
+sum(frequency_tbl_mult$proportion_lab_multiple) #3% data lost

--- a/data_cleaning.R
+++ b/data_cleaning.R
@@ -582,13 +582,10 @@ clean_NA <- clean_NA %>%
     age_interval_group = factor(age_interval_group, levels = c("0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34", "35-39", "40-44", "45-49", "50-54", "55-59", "60-64", "65-69", "70-74", "75-79", "80-84", "85+"))
   )
 
-# TO MERGE DUPLICATE PCRKEY AND KEEP ALL COL INFORMATION:
+# TO MERGE DUPLICATE PCRKEY:
 source("cols_causing_duplication.R")
 #replace conflicting columns causing duplication with "Multiple" and keep max datetime_of_...
-dupe_cols_df <- preprocess_merge()
-final_clean_NA <- paste_by_multiple(dupe_cols_df)
-#check for no leaked duplicates in final_clean_NA
-dupe_check(final_clean_NA)
+final_clean_NA <- paste_by_multiple()
 
 
 # Location table ----------------------------------------------------------


### PR DESCRIPTION
Added a function (paste_by_multiple()) in cols_causing_duplication.R that users can use in data_cleaning.R

This function replaces the values that conflict and cause duplicate PcrKeys with string "Multiple"

For "datetime_of_destination_prearrival_alert_or_activation" which is causing some minor duplciate PcrKeys, I kept the max date and added the difference between the earliest and latest date as a new variable in final_clean_NA: final_clean_NA$dt_of_dpaa_duration

Final results: 3% of data (where the column is a string type) in final_clean_NA has been replaced with "Multiple"